### PR TITLE
psychmeta Version 1.0.3 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: psychmeta
 Type: Package
 Title: Psychometric Meta-Analysis Toolkit
 Version: 1.0.2.99
-Date: 2018-05-01
+Date: 2018-05-08
 Authors@R: c(person("Jeffrey A.", "Dahlke", role = c("aut", "cre"),
                      email = "dahlk068@umn.edu"),
               person("Brenton M.", "Wiernik", role = "aut", email = "psychmeta@wiernik.org"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: psychmeta
 Type: Package
 Title: Psychometric Meta-Analysis Toolkit
-Version: 1.0.2.99
+Version: 1.0.3
 Date: 2018-05-08
 Authors@R: c(person("Jeffrey A.", "Dahlke", role = c("aut", "cre"),
                      email = "dahlk068@umn.edu"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: psychmeta
 Type: Package
 Title: Psychometric Meta-Analysis Toolkit
-Version: 1.0.2
+Version: 1.0.2.99
 Date: 2018-05-01
 Authors@R: c(person("Jeffrey A.", "Dahlke", role = c("aut", "cre"),
                      email = "dahlk068@umn.edu"),

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-Changes in Version 1.0.2.99
+Changes in Version 1.0.3 (2018-05-08)
 =====================================
 - The performance of the "hs_override" argument has been improved in ma_r and ma_d by correcting a bug that caused the argument to not be evaluated when running an artifact-distribution meta-analysis or only a bare-bones meta-analysis.  
 

--- a/NEWS
+++ b/NEWS
@@ -1,94 +1,129 @@
+Changes in Version 1.0.2.99
+=====================================
+- The performance of the "hs_override" argument has been improved in ma_r and ma_d by correcting a bug that caused the argument to not be evaluated when running an artifact-distribution meta-analysis or only a bare-bones meta-analysis.  
+
+- The default value for the "use_all_arts" argument in ma_r and ma_d has been changed from FALSE to TRUE. This is meant to improve the ease with which the most robust artifact-distribution corrections can be applied. 
+
+
 Changes in Version 1.0.2 (2018-05-01)
 =====================================
-o Bug fixes have been made for defining confidence-interval method in bare-bones and artifact-distribution meta-analyses computed with the ma_r function. 
-o A new “seed” argument has been added to ma_r and ma_d to set the seed value when imputing artifacts for greater reproducibility. 
-o New console messages have been introduced for when follow-up results are added to a meta-analysis object. 
+- Bug fixes have been made for defining confidence-interval method in bare-bones and artifact-distribution meta-analyses computed with the ma_r function. 
+
+- A new “seed” argument has been added to ma_r and ma_d to set the seed value when imputing artifacts for greater reproducibility. 
+
+- New console messages have been introduced for when follow-up results are added to a meta-analysis object. 
+
 
 Changes in Version 1.0.1 (2018-04-25)
 =====================================
-o Bug fixes for using true-score u ratios in individual-correction meta-analyses.
-o Bug fix for appropriately returning results from the compute_dmod function.
+- Bug fixes for using true-score u ratios in individual-correction meta-analyses.
+
+- Bug fix for appropriately returning results from the compute_dmod function.
+
 
 Changes in Version 1.0.0 (2018-04-17)
 =====================================
-o New “citekey” arguments have been added to meta-analysis function that allow users to supply citation keys for use in reference-management programs. The new generate_bib() function can harvest the citation keys from studies that are included in meta-analysis objects and create formatted reference lists for use in publications. 
-o Plotting functions have been added. The plot_forest() and plot_funnel() functions use ggplot2 to create forest and funnel plots, respectively. These functions take a meta-analysis object as an input and add a list of plots to the object. 
-o New functions to retrieve results from within meta-analysis objects have been added. The “get_stuff” family of functions provide easy ways to extract meta-analysis tables, follow-up analyses (e.g., cumulative meta-analyses, leave-one-out meta-analyses, bootstrap results), plots, and more. 
-o Assorted bug fixes have been implemented to improve the stability of the dependency resolution process, the handling of artifact distributions, and the accommodation of continuous moderators. 
+- New “citekey” arguments have been added to meta-analysis function that allow users to supply citation keys for use in reference-management programs. The new generate_bib() function can harvest the citation keys from studies that are included in meta-analysis objects and create formatted reference lists for use in publications. 
+
+- Plotting functions have been added. The plot_forest() and plot_funnel() functions use ggplot2 to create forest and funnel plots, respectively. These functions take a meta-analysis object as an input and add a list of plots to the object. 
+
+- New functions to retrieve results from within meta-analysis objects have been added. The “get_stuff” family of functions provide easy ways to extract meta-analysis tables, follow-up analyses (e.g., cumulative meta-analyses, leave-one-out meta-analyses, bootstrap results), plots, and more. 
+
+- Assorted bug fixes have been implemented to improve the stability of the dependency resolution process, the handling of artifact distributions, and the accommodation of continuous moderators. 
+
 
 Changes in Version 0.2.5 (2018-03-21)
 =====================================
-o Hot fix for consolidating dependent effect sizes. 
+- Hot fix for consolidating dependent effect sizes. 
+
 
 Changes in Version 0.2.4 (2018-03-20)
 =====================================
-o A new method to account for sampling error in interactive artifact distributions has been added (NOTE: this is now the default methods used in interactive AD meta-analyses).
-o Stability improvements for dMod functions.
-o Artifacts harvested from rows of a database that do not contain effects sizes in the ma_r and ma_d functions are now organized to avoid redundancy with observations from the same sample that are included in the meta-analytic computations. 
-o Bug fixes to metabulate(). 
+- A new method to account for sampling error in interactive artifact distributions has been added (NOTE: this is now the default methods used in interactive AD meta-analyses).
+
+- Stability improvements for dMod functions.
+
+- Artifacts harvested from rows of a database that do not contain effects sizes in the ma_r and ma_d functions are now organized to avoid redundancy with observations from the same sample that are included in the meta-analytic computations. 
+
+- Bug fixes to metabulate(). 
+
 
 Changes in Version 0.2.3 (2018-02-09)
 =====================================
-o Bug fix to the interactive artifact-distribution method for bivariate indirect range restriction (bvirr) to properly compute SD rho.
-o Bug fix to allow interactive artifact distributions to be rounded to the desired number of decimal places.
-o Bug fix for computing the mean reliability indices in the Taylor-series estimate of the corrected error variance for correlations corrected with the bivariate indirect range restriction (bvirr) correction.
+- Bug fix to the interactive artifact-distribution method for bivariate indirect range restriction (bvirr) to properly compute SD rho.
+
+- Bug fix to allow interactive artifact distributions to be rounded to the desired number of decimal places.
+
+- Bug fix for computing the mean reliability indices in the Taylor-series estimate of the corrected error variance for correlations corrected with the bivariate indirect range restriction (bvirr) correction.
+
 
 Changes in Version 0.2.2 (2018-01-24)
 =====================================
-o A new function (called matreg, with aliases of matrixreg, lm_mat, and lm_matrix) has been added that computes regression models from covariance matrices and vectors of means and generates output that resembles that of the "lm" function. Output from matreg can be used with the summary(), predict(), and confint() functions. 
-o The ma_r and mad_d functions have been modified to allow for more flexibility in computing multiple meta-analyses in a single function call, especially when those meta-analyses use artifact-distribution corrections. Several new arguments have been added to allow users to name the types artifact corrections they would like to apply to each construct - see function documentation for argument details.
-o The correct_rxx and correct_ryy arguments across meta-analysis routines (excluding ma_r_ad and ma_d_ad) can now support both scalar and vector arguments.
-o Efficiency improvements and improvements to the accuracy of progress-bar feedback have been made to the simulate_r_database and simulate_d_database functions.
+- A new function (called matreg, with aliases of matrixreg, lm_mat, and lm_matrix) has been added that computes regression models from covariance matrices and vectors of means and generates output that resembles that of the "lm" function. Output from matreg can be used with the summary(), predict(), and confint() functions. 
+
+- The ma_r and mad_d functions have been modified to allow for more flexibility in computing multiple meta-analyses in a single function call, especially when those meta-analyses use artifact-distribution corrections. Several new arguments have been added to allow users to name the types artifact corrections they would like to apply to each construct - see function documentation for argument details.
+
+- The correct_rxx and correct_ryy arguments across meta-analysis routines (excluding ma_r_ad and ma_d_ad) can now support both scalar and vector arguments.
+
+- Efficiency improvements and improvements to the accuracy of progress-bar feedback have been made to the simulate_r_database and simulate_d_database functions.
+
 
 Changes in Version 0.2.1 (2018-01-07)
 =====================================
-o Hotfixes for bugs in “simulate_d_sample” function affecting composite variables.
-o A “k_items_vec” argument is now included in the “simulate_psych” function.
-o The “simulate_d_database” function has been improved for faster computations. 
+- Hotfixes for bugs in “simulate_d_sample” function affecting composite variables.
+- A “k_items_vec” argument is now included in the “simulate_psych” function.
+- The “simulate_d_database” function has been improved for faster computations. 
+
 
 Changes in Version 0.2.0 (2018-01-05)
 =====================================
-o Bug fixes for identifying independent artifacts in artifact-distribution meta-analyses using ma_r and ma_d.
-o The simulation functions (simulate_r_sample, simulate_r_database, simulate_d_sample, simulate_d_database) can now simulate alpha reliabilities for variables when the number of items in a scale is indicated with the “k_items_vec” or “k_items_params” arguments. 
-o A new function called “metabulate" has been added that writes meta-analytic tables as rich text files with near publication-quality formatting. 
+- Bug fixes for identifying independent artifacts in artifact-distribution meta-analyses using ma_r and ma_d.
+- The simulation functions (simulate_r_sample, simulate_r_database, simulate_d_sample, simulate_d_database) can now simulate alpha reliabilities for variables when the number of items in a scale is indicated with the “k_items_vec” or “k_items_params” arguments. 
+- A new function called “metabulate" has been added that writes meta-analytic tables as rich text files with near publication-quality formatting. 
+
 
 Changes in Version 0.1.3 (2017-12-13)
 =====================================
-o Bug fixes and stability improvements for moderator analyses, the creation of artifact distributions, and computation of follow-up analyses.
-o Added reliability types arguments (e.g., “rxx_type”, “ryy_type”) to functions requiring reliability estimates to be corrected for range restriction. String vectors of reliability labels (e.g., “alpha”, “retest”, “parallel”; see documentation for the ma_r function for a complete list of supported labels) can now be supplied to many functions. When direct range restriction occurs, different corrections for range restriction are applied to internal-consistency reliability estimates and reliability estimates computed by correlating data from different testing occasions. 
-o The ma_r and ma_d functions now allow users to supply lists of external artifact information using the “supplemental_ads” argument (the ma_r_ic and ma_d_ic functions also allow this with the “supplemental_ads_x” and “supplemental_ads_y” arguments). These functions can also now harvest artifact information from studies in a database with invalid or missing effect sizes by setting the “use_all_arts” argument to TRUE.
-o “rho_params” arguments to the simulate_r_database function can now be supplied as a correlation matrix rather than a list (for situations in which samples are drawn from a single population). Similarly, elements in the “rho_params” list argument for the simulate_d_database can include matrices.
-o Progress bars have been added to potentially time-consuming functions to provide feedback about the percentage of progress and the estimated time remaining.
+- Bug fixes and stability improvements for moderator analyses, the creation of artifact distributions, and computation of follow-up analyses.
+
+- Added reliability types arguments (e.g., “rxx_type”, “ryy_type”) to functions requiring reliability estimates to be corrected for range restriction. String vectors of reliability labels (e.g., “alpha”, “retest”, “parallel”; see documentation for the ma_r function for a complete list of supported labels) can now be supplied to many functions. When direct range restriction occurs, different corrections for range restriction are applied to internal-consistency reliability estimates and reliability estimates computed by correlating data from different testing occasions. 
+
+- The ma_r and ma_d functions now allow users to supply lists of external artifact information using the “supplemental_ads” argument (the ma_r_ic and ma_d_ic functions also allow this with the “supplemental_ads_x” and “supplemental_ads_y” arguments). These functions can also now harvest artifact information from studies in a database with invalid or missing effect sizes by setting the “use_all_arts” argument to TRUE.
+
+- “rho_params” arguments to the simulate_r_database function can now be supplied as a correlation matrix rather than a list (for situations in which samples are drawn from a single population). Similarly, elements in the “rho_params” list argument for the simulate_d_database can include matrices.
+
+- Progress bars have been added to potentially time-consuming functions to provide feedback about the percentage of progress and the estimated time remaining.
 
 
 Changes in Version 0.1.2 (2017-11-16)
 =====================================
-o Bug fixes for moderator analyses.
-o Bug fixes for specifying the order of constructs and selecting a
+- Bug fixes for moderator analyses.
+
+- Bug fixes for specifying the order of constructs and selecting a
 subset of constructs in a database.
-o New function to correct for scale coarseness.
-o Improved vectorization support.
+
+- New function to correct for scale coarseness.
+
+- Improved vectorization support.
 
 
 Changes in Version 0.1.1 (2017-09-21)
 =====================================
+- We have added a suite of simulation function for d values (see the "simulate_d_sample" and "simulate_d_database" functions).
 
-o We have added a suite of simulation function for d values (see the "simulate_d_sample" and "simulate_d_database" functions).
+- Methods for meta-analyzing d values have been updated to better account for subgroup proportions when converting between the r and d metrics. The escalc objects that accompany a meta-analysis of d values now include more detailed information about incumbent and applicant subgroup proportions and the default for the "pa" argument (i.e., applicant proportions) is now NULL rather than .5 to prevent unintended corrections for range restriction.
 
-o Methods for meta-analyzing d values have been updated to better account for subgroup proportions when converting between the r and d metrics. The escalc objects that accompany a meta-analysis of d values now include more detailed information about incumbent and applicant subgroup proportions and the default for the "pa" argument (i.e., applicant proportions) is now NULL rather than .5 to prevent unintended corrections for range restriction.
+- A new "ma_generic" function has been added that allow users to do a psychmeta-style meta-analysis for any effect size for which the user has error-variance estimates. This function is supported by psychmeta's sensitivity() and heterogeneity() functions.
 
-o A new "ma_generic" function has been added that allow users to do a psychmeta-style meta-analysis for any effect size for which the user has error-variance estimates. This function is supported by psychmeta's sensitivity() and heterogeneity() functions.
+- Taylor series methods for estimating the variance of converted artifact values (e.g., a rxxi distribution converted to a rxxa distribution) have been expanded to account for the correlation between artifact distributions when such information is available. Correlations among  artifacts' sampling distributions can also be passed to the var_error_r_bvirr() function when it is called outside of a meta-analysis routine. 
 
-o Taylor series methods for estimating the variance of converted artifact values (e.g., a rxxi distribution converted to a rxxa distribution) have been expanded to account for the correlation between artifact distributions when such information is available. Correlations among  artifacts' sampling distributions can also be passed to the var_error_r_bvirr() function when it is called outside of a meta-analysis routine. 
+- The implementation of corrections of bivariate range restriction in individual-correction meta-analyses have been updated. Corrections for bivariate direct range restriction now use conventional compound attenuation factors, while the attenuation factors for bivariate indirect range restriction are now computed using mean effect sizes and artifacts to estimate sampling variances.
 
-o The implementation of corrections of bivariate range restriction in individual-correction meta-analyses have been updated. Corrections for bivariate direct range restriction now use conventional compound attenuation factors, while the attenuation factors for bivariate indirect range restriction are now computed using mean effect sizes and artifacts to estimate sampling variances.
-
-o Assorted bugs have been fixed (e.g., an error that occurred when running multi-construct meta-analyses without specifying moderators; filters to retain valid correlations did not screen construct names, sample ids, or measure names; subgroup proportions were not being retained when d values were meta-analyzed as correlations).
+- Assorted bugs have been fixed (e.g., an error that occurred when running multi-construct meta-analyses without specifying moderators; filters to retain valid correlations did not screen construct names, sample ids, or measure names; subgroup proportions were not being retained when d values were meta-analyzed as correlations).
 
 
 Changes in Version 0.1.0 (2017-08-15)
 =====================================
+- psychmeta has officially launched for public beta!
 
-o psychmeta has officially launched for public beta!
-
-o Please see the "psychmeta-package" entry in the psychmeta manual for an overview of the package and its applications. 
+- Please see the "psychmeta-package" entry in the psychmeta manual for an overview of the package and its applications. 

--- a/R/ma_d.R
+++ b/R/ma_d.R
@@ -78,9 +78,14 @@
 #' @param impute_method Method to use for imputing artifacts. See the documentation for \code{\link{ma_r}} for a list of available imputation methods.
 #' @param seed Seed value to use for imputing artifacts. Default value is 42.
 #' @param decimals Number of decimal places to which results should be rounded (default is to perform no rounding).
-#' @param hs_override When \code{TRUE}, this will override settings for \code{wt_type} (will set to "sample_size"), \code{error_type} (will set to "mean"),
-#' \code{correct_bias} (will set to \code{TRUE}), \code{conf_method} (will set to "norm"), \code{cred_method} (will set to "norm"), and \code{var_unbiased} (will set to \code{FALSE}).
-#' @param use_all_arts Logical scalar that determines whether artifact values from studies without valid effect sizes should be used in artifact distributions (\code{TRUE}) or not (\code{FALSE}).
+#' @param hs_override When \code{TRUE}, this will override settings for \code{wt_type} (will set to "sample_size"), 
+#' \code{error_type} (will set to "mean"),
+#' \code{correct_bias} (will set to \code{TRUE}), 
+#' \code{conf_method} (will set to "norm"),
+#' \code{cred_method} (will set to "norm"), 
+#' \code{var_unbiased} (will set to \code{FALSE}), 
+#' and \code{use_all_arts} (will set to \code{FALSE}).
+#' @param use_all_arts Logical scalar that determines whether artifact values from studies without valid effect sizes should be used in artifact distributions (\code{TRUE}; default) or not (\code{FALSE}).
 #' @param estimate_pa Logical scalar that determines whether the unrestricted subgroup proportions associated with univariate-range-restricted effect sizes should be estimated by rescaling the range-restricted subgroup proportions as a function of the range-restriction correction (\code{TRUE}) or not (\code{FALSE}; default).
 #' @param supplemental_ads Named list (named according to the constructs included in the meta-analysis) of supplemental artifact distribution information from studies not included in the meta-analysis. This is a list of lists, where the elements of a list associated with a construct are named like the arguments of the \code{create_ad()} function.
 #' @param data Data frame containing columns whose names may be provided as arguments to vector arguments and/or moderators.
@@ -222,10 +227,20 @@ ma_d <- function(d, n1, n2 = NULL, n_adj = NULL, sample_id = NULL, citekey = NUL
                  pairwise_ads = FALSE, residual_ads = TRUE,
                  check_dependence = TRUE, collapse_method = "composite", intercor = .5, partial_intercor = FALSE,
                  clean_artifacts = TRUE, impute_artifacts = ifelse(ma_method == "ad", FALSE, TRUE), impute_method = "bootstrap_mod", seed = 42,
-                 decimals = 2, hs_override = FALSE, use_all_arts = FALSE, estimate_pa = FALSE, supplemental_ads = NULL, data = NULL, ...){
+                 decimals = 2, hs_override = FALSE, use_all_arts = TRUE, estimate_pa = FALSE, supplemental_ads = NULL, data = NULL, ...){
 
      ##### Get inputs #####
      call <- match.call()
+     
+     if(hs_override){
+          wt_type <- "sample_size"
+          error_type <- "mean"
+          correct_bias <- TRUE
+          conf_method <- cred_method <- "norm"
+          var_unbiased <- FALSE
+          residual_ads <- FALSE
+     }
+     
      inputs <- list(wt_type = wt_type, error_type = error_type,
                     correct_bias = correct_bias, correct_rGg = correct_rGg, correct_ryy = correct_ryy,
                     conf_level = conf_level, cred_level = cred_level, cred_method = cred_method, var_unbiased = var_unbiased,
@@ -484,7 +499,7 @@ ma_d <- function(d, n1, n2 = NULL, n_adj = NULL, sample_id = NULL, citekey = NUL
                  pairwise_ads = pairwise_ads, residual_ads = residual_ads,
                  check_dependence = check_dependence, collapse_method = collapse_method, intercor = intercor,
                  clean_artifacts = clean_artifacts, impute_artifacts = impute_artifacts, impute_method = impute_method, seed = seed,
-                 hs_override = hs_override, decimals = decimals, use_all_arts = use_all_arts, supplemental_ads = supplemental_ads, data = NULL,
+                 decimals = decimals, use_all_arts = use_all_arts, supplemental_ads = supplemental_ads, data = NULL,
 
                  ## Ellipsis arguments - pass d value information to ma_r to facilitate effect-size metric conversions
                  use_as_x = group_order, use_as_y = construct_order,

--- a/R/ma_r.R
+++ b/R/ma_r.R
@@ -109,9 +109,14 @@
 #' }
 #' If an imputation method ending in "mod" is selected but no moderators are provided, the "mod" suffix will internally be replaced with "full".
 #' @param decimals Number of decimal places to which interactive artifact distributions should be rounded (default is 2 decimal places).
-#' @param hs_override When \code{TRUE}, this will override settings for \code{wt_type} (will set to "sample_size"), \code{error_type} (will set to "mean"),
-#' \code{correct_bias} (will set to \code{TRUE}), \code{conf_method} (will set to "norm"), \code{cred_method} (will set to "norm"), and \code{var_unbiased} (will set to \code{FALSE}).
-#' @param use_all_arts Logical scalar that determines whether artifact values from studies without valid effect sizes should be used in artifact distributions (\code{TRUE}) or not (\code{FALSE}).
+#' @param hs_override When \code{TRUE}, this will override settings for \code{wt_type} (will set to "sample_size"), 
+#' \code{error_type} (will set to "mean"),
+#' \code{correct_bias} (will set to \code{TRUE}), 
+#' \code{conf_method} (will set to "norm"),
+#' \code{cred_method} (will set to "norm"), 
+#' \code{var_unbiased} (will set to \code{FALSE}), 
+#' and \code{use_all_arts} (will set to \code{FALSE}).
+#' @param use_all_arts Logical scalar that determines whether artifact values from studies without valid effect sizes should be used in artifact distributions (\code{TRUE}; default) or not (\code{FALSE}).
 #' @param supplemental_ads Named list (named according to the constructs included in the meta-analysis) of supplemental artifact distribution information from studies not included in the meta-analysis. This is a list of lists, where the elements of a list associated with a construct are named like the arguments of the \code{create_ad()} function.
 #' @param data Data frame containing columns whose names may be provided as arguments to vector arguments and/or moderators.
 #' @param ... Further arguments to be passed to functions called within the meta-analysis.
@@ -331,11 +336,21 @@ ma_r <- function(rxyi, n, n_adj = NULL, sample_id = NULL, citekey = NULL,
                  pairwise_ads = FALSE,  residual_ads = TRUE,
                  check_dependence = TRUE, collapse_method = "composite", intercor = .5,
                  clean_artifacts = TRUE, impute_artifacts = ifelse(ma_method == "ad", FALSE, TRUE), impute_method = "bootstrap_mod", seed = 42,
-                 decimals = 2, hs_override = FALSE, use_all_arts = FALSE, supplemental_ads = NULL, data = NULL, ...){
+                 decimals = 2, hs_override = FALSE, use_all_arts = TRUE, supplemental_ads = NULL, data = NULL, ...){
 
      ##### Get inputs #####
      call <- match.call()
      warn_obj1 <- record_warnings()
+     
+     if(hs_override){
+          wt_type <- "sample_size"
+          error_type <- "mean"
+          correct_bias <- TRUE
+          conf_method <- cred_method <- "norm"
+          var_unbiased <- FALSE
+          residual_ads <- FALSE
+     }
+     
      inputs <- list(wt_type = wt_type, error_type = error_type, pairwise_ads = pairwise_ads,
                     correct_bias = correct_bias, correct_rxx = correct_rxx, correct_ryy = correct_ryy,
                     conf_level = conf_level, cred_level = cred_level, cred_method = cred_method, var_unbiased = var_unbiased,
@@ -1239,7 +1254,7 @@ ma_r <- function(rxyi, n, n_adj = NULL, sample_id = NULL, citekey = NULL,
                colnames(.psychmeta_reserved_internal_mod_aabbccddxxyyzz) <- moderator_names[["all"]]
 
                out <- ma_r_ic(rxyi = "rxyi", n = "n", n_adj = "n_adj", sample_id = "sample_id", citekey = "citekey",
-                              hs_override = hs_override, wt_type = wt_type, error_type = error_type,
+                              wt_type = wt_type, error_type = error_type,
                               correct_bias = correct_bias, correct_rxx = "correct_rxx", correct_ryy = "correct_ryy",
                               correct_rr_x = "correct_rr_x", correct_rr_y = "correct_rr_y",
                               indirect_rr_x = "indirect_rr_x", indirect_rr_y = "indirect_rr_y",

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -24,22 +24,39 @@ globalVariables(c(".", "Value",                                  ## Global varia
          pkg_badge <- xml2::read_html("http://www.r-pkg.org/badges/version/psychmeta")
          cran_v_char <- gsub(x = stringr::str_split(as.character(pkg_badge), "\n")[[1]][9], pattern = " ", replacement = "")
          cran_v_num <- as.numeric(stringr::str_split(cran_v_char, "[.]")[[1]])
-         sys_v_num <- as.numeric(stringr::str_split(version, "[.]")[[1]])
+         sys_v_char <- stringr::str_split(version, "[.]")[[1]]
+         sys_v_num <- as.numeric(sys_v_char)
+
+         if(cran_v_char == version){
+              out_of_date <- FALSE
+         }else{
+              best_version <- sort(c(CRAN = cran_v_char, Local = version), decreasing = TRUE)[1]
+              out_of_date <- names(best_version) == "CRAN"
+         }
 
          if(length(cran_v_num) == 3) cran_v_num <- c(cran_v_num, 0)
          if(length(sys_v_num) == 3) sys_v_num <- c(sys_v_num, 0)
-         vcheck <- sys_v_num < cran_v_num
-
-         out_of_date <- vcheck[1] | all(vcheck[1:2]) | all(vcheck[1:3]) | all(vcheck[1:4])
+         vcheck_equal <- sys_v_num == cran_v_num
+         vcheck_greater <- zapsmall(sys_v_num) > zapsmall(cran_v_num)
+         vcheck <- vcheck_equal | vcheck_greater
+         development <- all(vcheck) & any(vcheck_greater)
+         
          if(out_of_date){
               # packageStartupMessage(paste("\n", crayon::red(cli::symbol$cross), "Oh no! It looks like your copy of psychmeta is out of date!"))
               packageStartupMessage("\nOh no! It looks like your copy of psychmeta is out of date!")
               packageStartupMessage("No worries, it's easy to obtain the latest version - just run the following command: \n")
               packageStartupMessage('                       update.packages("psychmeta")')
          }else{
-              # packageStartupMessage(paste("\n", crayon::green(cli::symbol$tick), 'Yay! Your copy of psychmeta is up to date!'))
-              packageStartupMessage(paste("\nYay! Your copy of psychmeta is up to date!"))
+              if(development){
+                   packageStartupMessage("\nKudos! Your copy of psychmeta is more recent than the current CRAN release!")    
+              }else{
+                   # packageStartupMessage(paste("\n", crayon::green(cli::symbol$tick), 'Yay! Your copy of psychmeta is up to date!'))
+                   packageStartupMessage("\nYay! Your copy of psychmeta is up to date!")    
+              }
          }
+         
+         if(sys_v_num[4] > 0)
+              packageStartupMessage(paste0("\nNOTE: You are currently using a UNRELEASED development build of psychmeta (augmentation of release v", paste(sys_v_char[1:3], collapse = "."), ")"))
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 psychmeta: Psychometric Meta-Analysis Toolkit
 ======================================
 
-[![Build Status](https://travis-ci.org/jadahlke/psychmeta.svg?branch=master)](https://travis-ci.org/jadahlke/psychmeta)
 [![CRAN Version](http://www.r-pkg.org/badges/version/psychmeta)](https://cran.r-project.org/package=psychmeta)
+[![Build Status](https://travis-ci.org/psychmeta/psychmeta.svg?branch=master)](https://travis-ci.org/psychmeta/psychmeta)
 [![Monthly Downloads](http://cranlogs.r-pkg.org/badges/psychmeta)](http://cranlogs.r-pkg.org/badges/psychmeta)
 [![Total Downloads](http://cranlogs.r-pkg.org/badges/grand-total/psychmeta)](http://cranlogs.r-pkg.org/badges/grand-total/psychmeta)
 
@@ -18,7 +18,7 @@ The official [CRAN release](https://cran.r-project.org/package=psychmeta) of `ps
 install.packages("psychmeta")
 ```
 
-The unofficial [GitHub release](https://github.com/jadahlke/psychmeta) of `psychmeta` reflects updates made to the package between official CRAN releases. Using the [devtools](https://cran.r-project.org/package=devtools) package, the GitHub release can be installed with the following code:
+Development versions of `psychmeta` from [GitHub](https://github.com/jadahlke/psychmeta) reflect updates made to the package between official CRAN releases. Using the [devtools](https://cran.r-project.org/package=devtools) package, the GitHub release can be installed with the following code:
 ```r
 install.packages("devtools")
 devtools::install_github("jadahlke/psychmeta")

--- a/man/ma_d.Rd
+++ b/man/ma_d.Rd
@@ -22,7 +22,7 @@ ma_d(d, n1, n2 = NULL, n_adj = NULL, sample_id = NULL, citekey = NULL,
   collapse_method = "composite", intercor = 0.5, partial_intercor = FALSE,
   clean_artifacts = TRUE, impute_artifacts = ifelse(ma_method == "ad",
   FALSE, TRUE), impute_method = "bootstrap_mod", seed = 42, decimals = 2,
-  hs_override = FALSE, use_all_arts = FALSE, estimate_pa = FALSE,
+  hs_override = FALSE, use_all_arts = TRUE, estimate_pa = FALSE,
   supplemental_ads = NULL, data = NULL, ...)
 }
 \arguments{
@@ -156,10 +156,15 @@ When imputation is performed, \code{clean_artifacts} is treated as \code{TRUE} s
 
 \item{decimals}{Number of decimal places to which results should be rounded (default is to perform no rounding).}
 
-\item{hs_override}{When \code{TRUE}, this will override settings for \code{wt_type} (will set to "sample_size"), \code{error_type} (will set to "mean"),
-\code{correct_bias} (will set to \code{TRUE}), \code{conf_method} (will set to "norm"), \code{cred_method} (will set to "norm"), and \code{var_unbiased} (will set to \code{FALSE}).}
+\item{hs_override}{When \code{TRUE}, this will override settings for \code{wt_type} (will set to "sample_size"), 
+\code{error_type} (will set to "mean"),
+\code{correct_bias} (will set to \code{TRUE}), 
+\code{conf_method} (will set to "norm"),
+\code{cred_method} (will set to "norm"), 
+\code{var_unbiased} (will set to \code{FALSE}), 
+and \code{use_all_arts} (will set to \code{FALSE}).}
 
-\item{use_all_arts}{Logical scalar that determines whether artifact values from studies without valid effect sizes should be used in artifact distributions (\code{TRUE}) or not (\code{FALSE}).}
+\item{use_all_arts}{Logical scalar that determines whether artifact values from studies without valid effect sizes should be used in artifact distributions (\code{TRUE}; default) or not (\code{FALSE}).}
 
 \item{estimate_pa}{Logical scalar that determines whether the unrestricted subgroup proportions associated with univariate-range-restricted effect sizes should be estimated by rescaling the range-restricted subgroup proportions as a function of the range-restriction correction (\code{TRUE}) or not (\code{FALSE}; default).}
 

--- a/man/ma_r.Rd
+++ b/man/ma_r.Rd
@@ -22,7 +22,7 @@ ma_r(rxyi, n, n_adj = NULL, sample_id = NULL, citekey = NULL,
   collapse_method = "composite", intercor = 0.5, clean_artifacts = TRUE,
   impute_artifacts = ifelse(ma_method == "ad", FALSE, TRUE),
   impute_method = "bootstrap_mod", seed = 42, decimals = 2,
-  hs_override = FALSE, use_all_arts = FALSE, supplemental_ads = NULL,
+  hs_override = FALSE, use_all_arts = TRUE, supplemental_ads = NULL,
   data = NULL, ...)
 }
 \arguments{
@@ -184,10 +184,15 @@ If an imputation method ending in "mod" is selected but no moderators are provid
 
 \item{decimals}{Number of decimal places to which interactive artifact distributions should be rounded (default is 2 decimal places).}
 
-\item{hs_override}{When \code{TRUE}, this will override settings for \code{wt_type} (will set to "sample_size"), \code{error_type} (will set to "mean"),
-\code{correct_bias} (will set to \code{TRUE}), \code{conf_method} (will set to "norm"), \code{cred_method} (will set to "norm"), and \code{var_unbiased} (will set to \code{FALSE}).}
+\item{hs_override}{When \code{TRUE}, this will override settings for \code{wt_type} (will set to "sample_size"), 
+\code{error_type} (will set to "mean"),
+\code{correct_bias} (will set to \code{TRUE}), 
+\code{conf_method} (will set to "norm"),
+\code{cred_method} (will set to "norm"), 
+\code{var_unbiased} (will set to \code{FALSE}), 
+and \code{use_all_arts} (will set to \code{FALSE}).}
 
-\item{use_all_arts}{Logical scalar that determines whether artifact values from studies without valid effect sizes should be used in artifact distributions (\code{TRUE}) or not (\code{FALSE}).}
+\item{use_all_arts}{Logical scalar that determines whether artifact values from studies without valid effect sizes should be used in artifact distributions (\code{TRUE}; default) or not (\code{FALSE}).}
 
 \item{supplemental_ads}{Named list (named according to the constructs included in the meta-analysis) of supplemental artifact distribution information from studies not included in the meta-analysis. This is a list of lists, where the elements of a list associated with a construct are named like the arguments of the \code{create_ad()} function.}
 


### PR DESCRIPTION
- The performance of the "hs_override" argument has been improved in ma_r and ma_d by correcting a bug that caused the argument to not be evaluated when running an artifact-distribution meta-analysis or only a bare-bones meta-analysis.  

- The default value for the "use_all_arts" argument in ma_r and ma_d has been changed from FALSE to TRUE. This is meant to improve the ease with which the most robust artifact-distribution corrections can be applied. 