### PR TITLE
Impute missing artifacts in ma_r_ic() when as_worker == TRUE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: psychmeta
 Type: Package
 Title: Psychometric Meta-Analysis Toolkit
-Version: 2.4.1
-Date: 2020-07-11
+Version: 2.4.2
+Date: 2020-08-18
 Authors@R: c(person("Jeffrey A.", "Dahlke", role = c("aut", "cre"),
                      email = "jdahlke@humrro.org"),
               person("Brenton M.", "Wiernik", role = "aut", email = "brenton@psychmeta.com"),

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
-Changes in development version
+Changes in Version 2.4.2 (2020-08-18)
 ======================================
+- Fixed a bug in which missing artifacts were sometimes not imputed when resolving dependency among observations.
+
 - Improved standard error for SD_res when var_unbiased == TRUE.
 
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Changes in development version
+======================================
+- Improved standard error for SD_res when var_unbiased == TRUE.
+
+
 Changes in Version 2.4.1 (2020-07-16)
 ======================================
 - Restore 'overview' vignette.

--- a/R/methods_print.R
+++ b/R/methods_print.R
@@ -437,7 +437,11 @@ print.ma_heterogeneity <- function(x, ..., digits = 3){
         cat("Random effects variance estimates")
         cat("\n---------------------------------\n")
 
-        cat("Hunter-Schmidt method:")
+        if (attributes(x)$revc_method == "HS") {
+          cat("Hunter-Schmidt method:")
+        } else {
+          cat("Hunter-Schmidt method (with k-correction):")
+        }
         cat("\n")
         cat("  ", sd_label, "  (tau):   ", round2char(x$HS_method$tau[1], digits = digits),
             ", SE = ", round2char(x$HS_method$tau[2], digits = digits), ", ",

--- a/man/conf.limits.nc.chisq.Rd
+++ b/man/conf.limits.nc.chisq.Rd
@@ -3,7 +3,7 @@
 \name{conf.limits.nc.chisq}
 \alias{conf.limits.nc.chisq}
 \title{Confidence limits for noncentral chi square parameters (function and documentation from package 'MBESS' version 4.4.3)
-Function to determine the noncentral parameter that leads to the observed \code{Chi.Square}-value, 
+Function to determine the noncentral parameter that leads to the observed \code{Chi.Square}-value,
 so that a confidence interval for the population noncentral chi-squrae value can be formed.}
 \usage{
 conf.limits.nc.chisq(
@@ -41,7 +41,7 @@ conf.limits.nc.chisq(
 }
 \description{
 Confidence limits for noncentral chi square parameters (function and documentation from package 'MBESS' version 4.4.3)
-Function to determine the noncentral parameter that leads to the observed \code{Chi.Square}-value, 
+Function to determine the noncentral parameter that leads to the observed \code{Chi.Square}-value,
 so that a confidence interval for the population noncentral chi-squrae value can be formed.
 }
 \details{


### PR DESCRIPTION
Reprex here: https://gist.github.com/bwiernik/99a0910944f3fa88cdf7cace45b5a060

This PR implements the third possible solution listed in the reprex. It imputes missing artifacts inside of ma_r_ic(). This is a straightforward approach. 

The alternative would be to impute before .remove_depency() in ma_r() when ma_method == "ic". That would allow it to compute composite artifacts on the imputed artifacts. Not sure if that would be better. If we did that, we would need to change how the ad_obj construction works inside ma_r_ic (e.g., to store whether artifacts were imputed or not) to get accurate values for the artifact distribution.